### PR TITLE
[CRITIQUE] Flutter Auth: Real authentication flow with backend

### DIFF
--- a/lib/core/config/api_config.dart
+++ b/lib/core/config/api_config.dart
@@ -1,0 +1,31 @@
+/// Centralized API configuration for AuditFlow
+/// Allows environment-specific configuration via dart-define
+class ApiConfig {
+  ApiConfig._();
+
+  /// Base URL for the backend API
+  static const String baseUrl = String.fromEnvironment(
+    'API_BASE_URL',
+    defaultValue: 'http://localhost:3000',
+  );
+
+  /// PowerSync WebSocket URL
+  static const String powerSyncUrl = String.fromEnvironment(
+    'POWERSYNC_URL',
+    defaultValue: 'ws://localhost:8080',
+  );
+
+  // Auth endpoints
+  static String get login => '$baseUrl/auth/login';
+  static String get register => '$baseUrl/auth/register';
+  static String get me => '$baseUrl/auth/me';
+
+  // Organization endpoints
+  static String get organizations => '$baseUrl/organizations';
+
+  // PowerSync endpoints
+  static String get powerSyncUpload => '$baseUrl/powersync/upload';
+
+  // Health check
+  static String get health => '$baseUrl/health';
+}

--- a/lib/core/providers/organization_provider.dart
+++ b/lib/core/providers/organization_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:dio/dio.dart';
 import '../../powersync/service.dart';
+import '../config/api_config.dart';
 
 /// Organization model
 class Organization {
@@ -135,7 +136,7 @@ class OrganizationProvider extends ChangeNotifier {
       _dio.options.headers['x-user-id'] = userId;
       _dio.options.headers['Authorization'] = 'Bearer $token';
 
-      final response = await _dio.get('http://localhost:3000/organizations');
+      final response = await _dio.get(ApiConfig.organizations);
 
       if (response.data['success'] == true) {
         final List<dynamic> orgsData = response.data['data'] ?? [];
@@ -185,7 +186,7 @@ class OrganizationProvider extends ChangeNotifier {
       _dio.options.headers['Authorization'] = 'Bearer $token';
 
       final response = await _dio.post(
-        'http://localhost:3000/organizations',
+        ApiConfig.organizations,
         data: {'name': name},
       );
 
@@ -225,7 +226,7 @@ class OrganizationProvider extends ChangeNotifier {
       _dio.options.headers['Authorization'] = 'Bearer $authToken';
 
       final response = await _dio.post(
-        'http://localhost:3000/organizations/join/$token',
+        '${ApiConfig.organizations}/join/$token',
       );
 
       if (response.data['success'] == true) {
@@ -273,7 +274,7 @@ class OrganizationProvider extends ChangeNotifier {
       _dio.options.headers['Authorization'] = 'Bearer $token';
 
       final response = await _dio.post(
-        'http://localhost:3000/organizations/${_activeOrganization!.id}/invite',
+        '${ApiConfig.organizations}/${_activeOrganization!.id}/invite',
         data: {'email': email},
       );
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,8 @@ import 'core/theme/app_theme.dart';
 import 'core/theme/theme_provider.dart';
 import 'core/widgets/theme_toggle_button.dart';
 import 'core/providers/organization_provider.dart';
+import 'services/auth_service.dart';
+import 'powersync/service.dart';
 import 'screens/landing/landing_screen.dart';
 import 'screens/auth/login_screen.dart';
 import 'screens/organization/organization_onboarding_screen.dart';
@@ -18,7 +20,12 @@ import 'screens/templates/create_template_screen.dart';
 import 'screens/results/results_screen.dart';
 import 'screens/settings/settings_screen.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // Initialize PowerSync
+  await PowerSyncService().initialize();
+
   runApp(const AuditFlowApp());
 }
 
@@ -67,10 +74,41 @@ class AuthWrapper extends StatefulWidget {
 
 class _AuthWrapperState extends State<AuthWrapper> {
   bool _isLoggedIn = false;
+  bool _isCheckingAuth = true;
   String? _userId;
   String? _token;
 
-  void _login(String userId, String token) {
+  final _authService = AuthService();
+  final _powerSyncService = PowerSyncService();
+
+  @override
+  void initState() {
+    super.initState();
+    _checkExistingAuth();
+  }
+
+  /// Check if user is already authenticated on app start
+  Future<void> _checkExistingAuth() async {
+    final isAuthenticated = await _authService.isAuthenticated();
+    if (isAuthenticated) {
+      final userId = await _authService.getUserId();
+      final token = await _authService.getToken();
+      if (userId != null && token != null) {
+        await _powerSyncService.connect(userId: userId, authToken: token);
+        setState(() {
+          _isLoggedIn = true;
+          _userId = userId;
+          _token = token;
+        });
+      }
+    }
+    setState(() => _isCheckingAuth = false);
+  }
+
+  void _login(String userId, String token) async {
+    // Connect PowerSync with the token
+    await _powerSyncService.connect(userId: userId, authToken: token);
+
     setState(() {
       _isLoggedIn = true;
       _userId = userId;
@@ -78,9 +116,16 @@ class _AuthWrapperState extends State<AuthWrapper> {
     });
   }
 
-  void _logout() {
+  void _logout() async {
+    // Logout from AuthService (clears stored token)
+    await _authService.logout();
+
+    // Disconnect PowerSync
+    await _powerSyncService.disconnect();
+
     final orgProvider = context.read<OrganizationProvider>();
     orgProvider.clear();
+
     setState(() {
       _isLoggedIn = false;
       _userId = null;
@@ -90,6 +135,17 @@ class _AuthWrapperState extends State<AuthWrapper> {
 
   @override
   Widget build(BuildContext context) {
+    // Show loading while checking existing auth
+    if (_isCheckingAuth) {
+      return const MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: CircularProgressIndicator(),
+          ),
+        ),
+      );
+    }
+
     if (!_isLoggedIn) {
       return LoginScreen(onLogin: _login);
     }

--- a/lib/powersync/service.dart
+++ b/lib/powersync/service.dart
@@ -6,6 +6,7 @@ import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:http/http.dart' as http;
 import 'package:uuid/uuid.dart';
+import '../core/config/api_config.dart';
 
 /// Schéma SQLite local pour PowerSync
 class PowerSyncSchema {
@@ -131,11 +132,8 @@ class PowerSyncService {
     _userId = userId;
 
     try {
-      // Endpoint Docker local - ws:// pour WebSocket
-      // Pour Android emulator: ws://10.0.2.2:8080
-      // Pour iOS simulator: ws://localhost:8080
-      // Pour device physique: ws://VOTRE_IP:8080
-      final powerSyncEndpoint = endpoint ?? 'ws://localhost:8080';
+      // Use centralized config
+      final powerSyncEndpoint = endpoint ?? ApiConfig.powerSyncUrl;
 
       final connector = _AuditFlowConnector(
         endpoint: powerSyncEndpoint,
@@ -484,7 +482,7 @@ class _AuditFlowConnector extends PowerSyncBackendConnector {
 
       // Appeler l'API backend avec http
       final response = await http.post(
-        Uri.parse('http://localhost:3000/powersync/upload'),
+        Uri.parse(ApiConfig.powerSyncUpload),
         headers: {
           'Authorization': 'Bearer $token',
           'Content-Type': 'application/json',

--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_animate/flutter_animate.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import '../../core/theme/theme_provider.dart';
 import '../../core/widgets/theme_toggle_button.dart';
+import '../../services/auth_service.dart';
 
 class LoginScreen extends StatefulWidget {
   final void Function(String userId, String token)? onLogin;
@@ -16,6 +17,59 @@ class LoginScreen extends StatefulWidget {
 class _LoginScreenState extends State<LoginScreen> {
   bool _isLogin = true;
   bool _obscurePassword = true;
+  bool _isLoading = false;
+  String? _errorMessage;
+
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _nameController = TextEditingController();
+  final _authService = AuthService();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    final email = _emailController.text.trim();
+    final password = _passwordController.text.trim();
+    final name = _nameController.text.trim();
+
+    if (email.isEmpty || password.isEmpty) {
+      setState(() => _errorMessage = 'Veuillez remplir tous les champs');
+      return;
+    }
+
+    if (!_isLogin && name.isEmpty) {
+      setState(() => _errorMessage = 'Veuillez entrer votre nom');
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final result = _isLogin
+          ? await _authService.login(email: email, password: password)
+          : await _authService.register(
+              email: email, password: password, name: name);
+
+      if (result.success && result.user != null && result.token != null) {
+        widget.onLogin?.call(result.user!.id, result.token!);
+      } else {
+        setState(() => _errorMessage = result.error ?? 'Erreur inconnue');
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -159,9 +213,34 @@ class _LoginScreenState extends State<LoginScreen> {
                           ],
                         ),
                         const SizedBox(height: 32),
+                        // Error message
+                        if (_errorMessage != null) ...[
+                          Container(
+                            padding: const EdgeInsets.all(12),
+                            decoration: BoxDecoration(
+                              color: Colors.red.withOpacity(0.1),
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: Row(
+                              children: [
+                                const Icon(FontAwesomeIcons.circleExclamation,
+                                    color: Colors.red, size: 16),
+                                const SizedBox(width: 8),
+                                Expanded(
+                                  child: Text(
+                                    _errorMessage!,
+                                    style: const TextStyle(color: Colors.red),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+                        ],
                         // Form
                         if (!_isLogin) ...[
                           TextField(
+                            controller: _nameController,
                             decoration: InputDecoration(
                               labelText: 'Nom complet',
                               prefixIcon: const Icon(FontAwesomeIcons.user),
@@ -178,6 +257,8 @@ class _LoginScreenState extends State<LoginScreen> {
                           const SizedBox(height: 16),
                         ],
                         TextField(
+                          controller: _emailController,
+                          keyboardType: TextInputType.emailAddress,
                           decoration: InputDecoration(
                             labelText: 'Email',
                             prefixIcon: const Icon(FontAwesomeIcons.envelope),
@@ -193,6 +274,7 @@ class _LoginScreenState extends State<LoginScreen> {
                         ),
                         const SizedBox(height: 16),
                         TextField(
+                          controller: _passwordController,
                           obscureText: _obscurePassword,
                           decoration: InputDecoration(
                             labelText: 'Mot de passe',
@@ -223,11 +305,7 @@ class _LoginScreenState extends State<LoginScreen> {
                         SizedBox(
                           width: double.infinity,
                           child: ElevatedButton(
-                            onPressed: () {
-                              // Demo login - accept any credentials
-                              widget.onLogin
-                                  ?.call('demo-user-id', 'demo-token');
-                            },
+                            onPressed: _isLoading ? null : _submit,
                             style: ElevatedButton.styleFrom(
                               padding: const EdgeInsets.symmetric(vertical: 16),
                               backgroundColor: theme.colorScheme.primary,
@@ -236,32 +314,22 @@ class _LoginScreenState extends State<LoginScreen> {
                                 borderRadius: BorderRadius.circular(12),
                               ),
                             ),
-                            child: Text(
-                              _isLogin ? 'Se connecter' : 'S\'inscrire',
-                              style: const TextStyle(
-                                fontSize: 16,
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
-                          ),
-                        ),
-                        const SizedBox(height: 24),
-                        // Demo quick login
-                        SizedBox(
-                          width: double.infinity,
-                          child: OutlinedButton.icon(
-                            onPressed: () {
-                              widget.onLogin
-                                  ?.call('demo-user-id', 'demo-token');
-                            },
-                            icon: const Icon(FontAwesomeIcons.bolt),
-                            label: const Text('Connexion rapide (Demo)'),
-                            style: OutlinedButton.styleFrom(
-                              padding: const EdgeInsets.symmetric(vertical: 16),
-                              side: BorderSide(
-                                  color: theme.colorScheme.secondary),
-                              foregroundColor: theme.colorScheme.secondary,
-                            ),
+                            child: _isLoading
+                                ? const SizedBox(
+                                    height: 20,
+                                    width: 20,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                      color: Colors.white,
+                                    ),
+                                  )
+                                : Text(
+                                    _isLogin ? 'Se connecter' : 'S\'inscrire',
+                                    style: const TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
                           ),
                         ),
                         const SizedBox(height: 24),

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,251 @@
+import 'package:dio/dio.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../core/config/api_config.dart';
+
+/// Authentication result
+class AuthResult {
+  final bool success;
+  final String? error;
+  final AuthUser? user;
+  final String? token;
+
+  AuthResult({
+    required this.success,
+    this.error,
+    this.user,
+    this.token,
+  });
+
+  factory AuthResult.fromJson(Map<String, dynamic> json) {
+    if (json['success'] == true && json['data'] != null) {
+      final data = json['data'] as Map<String, dynamic>;
+      return AuthResult(
+        success: true,
+        user: AuthUser.fromJson(data['user'] as Map<String, dynamic>),
+        token: data['token'] as String?,
+      );
+    }
+    return AuthResult(
+      success: false,
+      error: json['error'] as String? ?? 'Une erreur est survenue',
+    );
+  }
+}
+
+/// User data from authentication
+class AuthUser {
+  final String id;
+  final String email;
+  final String? name;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  AuthUser({
+    required this.id,
+    required this.email,
+    this.name,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  factory AuthUser.fromJson(Map<String, dynamic> json) {
+    return AuthUser(
+      id: json['id'] as String,
+      email: json['email'] as String,
+      name: json['name'] as String?,
+      createdAt: json['createdAt'] != null
+          ? DateTime.parse(json['createdAt'] as String)
+          : null,
+      updatedAt: json['updatedAt'] != null
+          ? DateTime.parse(json['updatedAt'] as String)
+          : null,
+    );
+  }
+}
+
+/// Service for handling authentication with the backend
+class AuthService {
+  static final AuthService _instance = AuthService._internal();
+  factory AuthService() => _instance;
+  AuthService._internal();
+
+  final Dio _dio = Dio(BaseOptions(
+    baseUrl: ApiConfig.baseUrl,
+    headers: {'Content-Type': 'application/json'},
+    connectTimeout: const Duration(seconds: 10),
+    receiveTimeout: const Duration(seconds: 10),
+  ));
+
+  static const String _tokenKey = 'auth_token';
+  static const String _userIdKey = 'user_id';
+  static const String _userEmailKey = 'user_email';
+  static const String _userNameKey = 'user_name';
+
+  /// Login with email and password
+  Future<AuthResult> login({
+    required String email,
+    required String password,
+  }) async {
+    try {
+      final response = await _dio.post(
+        ApiConfig.login,
+        data: {'email': email, 'password': password},
+      );
+
+      final result = AuthResult.fromJson(response.data);
+
+      if (result.success && result.token != null) {
+        await _saveAuthData(
+          token: result.token!,
+          userId: result.user!.id,
+          email: result.user!.email,
+          name: result.user!.name,
+        );
+      }
+
+      return result;
+    } on DioException catch (e) {
+      return _handleDioError(e);
+    } catch (e) {
+      return AuthResult(success: false, error: 'Erreur inattendue: $e');
+    }
+  }
+
+  /// Register a new user
+  Future<AuthResult> register({
+    required String email,
+    required String password,
+    String? name,
+  }) async {
+    try {
+      final response = await _dio.post(
+        ApiConfig.register,
+        data: {
+          'email': email,
+          'password': password,
+          if (name != null && name.isNotEmpty) 'name': name,
+        },
+      );
+
+      final result = AuthResult.fromJson(response.data);
+
+      if (result.success && result.token != null) {
+        await _saveAuthData(
+          token: result.token!,
+          userId: result.user!.id,
+          email: result.user!.email,
+          name: result.user!.name,
+        );
+      }
+
+      return result;
+    } on DioException catch (e) {
+      return _handleDioError(e);
+    } catch (e) {
+      return AuthResult(success: false, error: 'Erreur inattendue: $e');
+    }
+  }
+
+  /// Get current user info from the backend
+  Future<AuthUser?> getCurrentUser() async {
+    final token = await getToken();
+    if (token == null) return null;
+
+    try {
+      final response = await _dio.get(
+        ApiConfig.me,
+        options: Options(headers: {'Authorization': 'Bearer $token'}),
+      );
+
+      if (response.data['success'] == true) {
+        return AuthUser.fromJson(response.data['data']);
+      }
+      return null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// Check if user is logged in
+  Future<bool> isAuthenticated() async {
+    final token = await getToken();
+    return token != null;
+  }
+
+  /// Get stored token
+  Future<String?> getToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_tokenKey);
+  }
+
+  /// Get stored user ID
+  Future<String?> getUserId() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_userIdKey);
+  }
+
+  /// Get stored user email
+  Future<String?> getUserEmail() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_userEmailKey);
+  }
+
+  /// Get stored user name
+  Future<String?> getUserName() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_userNameKey);
+  }
+
+  /// Logout and clear stored data
+  Future<void> logout() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_tokenKey);
+    await prefs.remove(_userIdKey);
+    await prefs.remove(_userEmailKey);
+    await prefs.remove(_userNameKey);
+  }
+
+  /// Save authentication data to local storage
+  Future<void> _saveAuthData({
+    required String token,
+    required String userId,
+    required String email,
+    String? name,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_tokenKey, token);
+    await prefs.setString(_userIdKey, userId);
+    await prefs.setString(_userEmailKey, email);
+    if (name != null) {
+      await prefs.setString(_userNameKey, name);
+    }
+  }
+
+  /// Handle Dio errors and return appropriate error message
+  AuthResult _handleDioError(DioException e) {
+    String errorMessage;
+
+    switch (e.type) {
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.sendTimeout:
+      case DioExceptionType.receiveTimeout:
+        errorMessage = 'Connexion au serveur impossible. Vérifiez votre connexion.';
+        break;
+      case DioExceptionType.badResponse:
+        final data = e.response?.data;
+        if (data is Map && data['error'] != null) {
+          errorMessage = data['error'] as String;
+        } else {
+          errorMessage = 'Erreur serveur (${e.response?.statusCode ?? 'inconnu'})';
+        }
+        break;
+      case DioExceptionType.connectionError:
+        errorMessage = 'Impossible de se connecter au serveur.';
+        break;
+      default:
+        errorMessage = 'Une erreur est survenue. Veuillez réessayer.';
+    }
+
+    return AuthResult(success: false, error: errorMessage);
+  }
+}


### PR DESCRIPTION
## Summary
Implémente le flux d'authentification réel avec le backend pour l'écran de login Flutter.

## Changes

### Nouveaux fichiers
- **`lib/services/auth_service.dart`**: Service d'authentification avec login/register via API backend
- **`lib/core/config/api_config.dart`**: Configuration centralisée des URLs API

### Fichiers modifiés
- **`lib/screens/auth/login_screen.dart`**: 
  - Connexion des TextFields aux controllers
  - Appel AuthService au lieu du mode démo
  - Affichage des erreurs et loading state
  - Suppression du bouton "Connexion rapide (Demo)"

- **`lib/main.dart`**:
  - Initialisation PowerSync au démarrage
  - Vérification auth existante (auto-login)
  - Connexion PowerSync après login
  - Déconnexion propre au logout

- **`lib/powersync/service.dart`**:
  - Utilisation de `ApiConfig.powerSyncUrl`
  - Utilisation de `ApiConfig.powerSyncUpload`

- **`lib/core/providers/organization_provider.dart`**:
  - Remplacement des URLs hardcodés par `ApiConfig.organizations`

## Files Changed
- `lib/services/auth_service.dart` - Nouveau service auth
- `lib/core/config/api_config.dart` - Config centralisée
- `lib/screens/auth/login_screen.dart` - UI login connectée
- `lib/main.dart` - Intégration auth + PowerSync
- `lib/powersync/service.dart` - URLs via config
- `lib/core/providers/organization_provider.dart` - URLs via config

## Testing
```bash
# Backend doit tourner
cd backend && npm run dev

# Flutter
flutter pub get
flutter run
```

## Checklist
- [x] Code compile (flutter build web --release)
- [x] Pas de secrets en dur
- [x] URLs centralisées dans ApiConfig
- [x] Token stocké dans SharedPreferences
- [x] Auto-login si token existant
- [x] Déconnexion propre

Closes #4