### PR TITLE
[MOYENNE] Create Template: Bouton sauvegarder inactif - implémenter createTemplate() PowerSync

### DIFF
--- a/lib/powersync/service.dart
+++ b/lib/powersync/service.dart
@@ -531,6 +531,69 @@ class PowerSyncService {
     return template;
   }
 
+  /// Crée un nouveau template avec ses questions
+  ///
+  /// [name] - Nom du template (requis)
+  /// [category] - Catégorie du template (requis)
+  /// [description] - Description optionnelle
+  /// [questions] - Liste des questions avec type, text, options, etc.
+  Future<Map<String, dynamic>> createTemplate({
+    required String name,
+    required String category,
+    String? description,
+    required List<Map<String, dynamic>> questions,
+  }) async {
+    if (_userId == null) throw StateError('User not authenticated');
+    if (_organizationId == null) throw StateError('No organization selected');
+
+    final id = _generateId();
+    final now = DateTime.now().toIso8601String();
+
+    // Insérer le template
+    await db.execute('''
+      INSERT INTO templates (id, name, description, category, organization_id, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    ''', [id, name, description, category, _organizationId, now, now]);
+
+    // Insérer les questions
+    for (var i = 0; i < questions.length; i++) {
+      final question = questions[i];
+      final questionId = _generateId();
+
+      await db.execute('''
+        INSERT INTO questions (id, template_id, type, text, category, "order", required, options, min, max, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ''', [
+        questionId,
+        id,
+        question['type'] as String? ?? 'text',
+        question['text'] as String? ?? '',
+        question['category'] as String? ?? category,
+        i + 1, // order (1-indexed)
+        question['required'] as bool? ?? false ? 1 : 0,
+        question['options'] != null
+            ? (question['options'] as List).join('|')
+            : null,
+        question['min'] as int?,
+        question['max'] as int?,
+        now,
+        now,
+      ]);
+    }
+
+    // Retourner le template créé
+    return {
+      'id': id,
+      'name': name,
+      'description': description,
+      'category': category,
+      'organization_id': _organizationId,
+      'created_at': now,
+      'updated_at': now,
+      'question_count': questions.length,
+    };
+  }
+
   /// Récupère les statistiques des audits (organisation)
   Future<Map<String, dynamic>> getAuditStats() async {
     if (_organizationId == null) {

--- a/lib/screens/templates/create_template_screen.dart
+++ b/lib/screens/templates/create_template_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import '../../powersync/service.dart';
 
 class CreateTemplateScreen extends StatefulWidget {
   const CreateTemplateScreen({super.key});
@@ -13,6 +14,9 @@ class _CreateTemplateScreenState extends State<CreateTemplateScreen> {
   final _descriptionController = TextEditingController();
   String? _selectedCategory;
   final List<Map<String, dynamic>> _questions = [];
+
+  bool _isSaving = false;
+  String? _validationError;
 
   final List<String> _categories = [
     'Qualité',
@@ -43,6 +47,54 @@ class _CreateTemplateScreenState extends State<CreateTemplateScreen> {
     });
   }
 
+  /// Sauvegarde le template dans PowerSync
+  Future<void> _saveTemplate() async {
+    // Validation
+    if (_titleController.text.trim().isEmpty) {
+      setState(() => _validationError = 'Le nom du template est requis');
+      return;
+    }
+    if (_selectedCategory == null) {
+      setState(() => _validationError = 'La catégorie est requise');
+      return;
+    }
+    if (_questions.isEmpty) {
+      setState(() => _validationError = 'Au moins une question est requise');
+      return;
+    }
+
+    setState(() {
+      _isSaving = true;
+      _validationError = null;
+    });
+
+    try {
+      await PowerSyncService().createTemplate(
+        name: _titleController.text.trim(),
+        category: _selectedCategory!,
+        description: _descriptionController.text.trim().isEmpty
+            ? null
+            : _descriptionController.text.trim(),
+        questions: _questions,
+      );
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Template créé avec succès'),
+            backgroundColor: Colors.green,
+          ),
+        );
+        Navigator.pop(context);
+      }
+    } catch (e) {
+      setState(() {
+        _isSaving = false;
+        _validationError = 'Erreur lors de la sauvegarde: $e';
+      });
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -56,9 +108,15 @@ class _CreateTemplateScreenState extends State<CreateTemplateScreen> {
         ),
         actions: [
           TextButton.icon(
-            onPressed: () {},
-            icon: const Icon(FontAwesomeIcons.floppyDisk),
-            label: const Text('Sauvegarder'),
+            onPressed: _isSaving ? null : _saveTemplate,
+            icon: _isSaving
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(FontAwesomeIcons.floppyDisk),
+            label: Text(_isSaving ? 'Sauvegarde...' : 'Sauvegarder'),
           ),
         ],
       ),
@@ -67,6 +125,30 @@ class _CreateTemplateScreenState extends State<CreateTemplateScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            // Validation error banner
+            if (_validationError != null)
+              Container(
+                margin: const EdgeInsets.only(bottom: 16),
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.red.withOpacity(0.1),
+                  borderRadius: BorderRadius.circular(8),
+                  border: Border.all(color: Colors.red.withOpacity(0.3)),
+                ),
+                child: Row(
+                  children: [
+                    Icon(FontAwesomeIcons.circleExclamation,
+                        color: Colors.red, size: 20),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        _validationError!,
+                        style: TextStyle(color: Colors.red),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             // Info section
             Text(
               'Informations générales',


### PR DESCRIPTION
## Summary
Implémenter la sauvegarde des templates avec questions dans PowerSync.

## Changes
- **lib/powersync/service.dart**: 
  - Nouvelle méthode createTemplate()
  - Insertion template + questions avec ordre

- **lib/screens/templates/create_template_screen.dart**: 
  - Wire du bouton sauvegarder
  - Validation (nom, catégorie, questions)
  - États loading/error
  - Navigation après succès

## Testing
\\\ash
flutter analyze lib/screens/templates/create_template_screen.dart
flutter build apk --debug
\\\

## Checklist
- [x] Code compile
- [x] Pas d'erreurs de lint (warnings withOpacity dépréciés)
- [x] Pas de secrets

Closes #9