### PR TITLE
[MOYENNE] Settings Categories: 6 catégories hardcodées - calculer depuis templates PowerSync

### DIFF
--- a/lib/screens/settings/settings_screen.dart
+++ b/lib/screens/settings/settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import '../../core/theme/theme_provider.dart';
+import '../../powersync/service.dart';
 
 class SettingsScreen extends StatefulWidget {
   final VoidCallback? onLogout;
@@ -455,66 +456,149 @@ class _AppearancePage extends StatelessWidget {
   }
 }
 
-class _CategoriesPage extends StatelessWidget {
+class _CategoriesPage extends StatefulWidget {
   final VoidCallback onBack;
   const _CategoriesPage({required this.onBack});
 
   @override
+  State<_CategoriesPage> createState() => _CategoriesPageState();
+}
+
+class _CategoriesPageState extends State<_CategoriesPage> {
+  bool _isLoading = true;
+  Map<String, int> _categoryCounts = {};
+
+  // Mapping des couleurs par catégorie
+  static const _categoryColors = {
+    'Qualité': Colors.blue,
+    'Sécurité': Colors.red,
+    'Environnement': Colors.green,
+    'Hygiène': Colors.orange,
+    'Technique': Colors.purple,
+    'Conformité': Colors.teal,
+  };
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCategories();
+  }
+
+  Future<void> _loadCategories() async {
+    try {
+      final templates = await PowerSyncService().getTemplates();
+
+      // Compter les templates par catégorie
+      final counts = <String, int>{};
+      for (final template in templates) {
+        final category = template['category'] as String? ?? 'Autre';
+        counts[category] = (counts[category] ?? 0) + 1;
+      }
+
+      setState(() {
+        _categoryCounts = counts;
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() => _isLoading = false);
+    }
+  }
+
+  Color _getCategoryColor(String category) {
+    return _categoryColors[category] ?? Colors.grey;
+  }
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final categories = [
-      {'name': 'Qualité', 'color': Colors.blue, 'count': 12},
-      {'name': 'Sécurité', 'color': Colors.red, 'count': 8},
-      {'name': 'Environnement', 'color': Colors.green, 'count': 6},
-      {'name': 'Hygiène', 'color': Colors.orange, 'count': 5},
-      {'name': 'Technique', 'color': Colors.purple, 'count': 4},
-      {'name': 'Conformité', 'color': Colors.teal, 'count': 7},
-    ];
+
+    // Catégories triées par count décroissant
+    final sortedCategories = _categoryCounts.keys.toList()
+      ..sort((a, b) => _categoryCounts[b]!.compareTo(_categoryCounts[a]!));
 
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(
           icon: const Icon(FontAwesomeIcons.arrowLeft),
-          onPressed: onBack,
+          onPressed: widget.onBack,
         ),
         title: const Text('Catégories'),
         actions: [
           IconButton(
             icon: const Icon(FontAwesomeIcons.plus),
-            onPressed: () {},
+            onPressed: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                    content: Text('Ajout de catégorie à implémenter')),
+              );
+            },
           ),
         ],
       ),
-      body: ListView.builder(
-        padding: const EdgeInsets.all(16),
-        itemCount: categories.length,
-        itemBuilder: (context, index) {
-          final cat = categories[index];
-          return Card(
-            child: ListTile(
-              leading: CircleAvatar(
-                backgroundColor: (cat['color'] as Color).withOpacity(0.2),
-                child: Icon(FontAwesomeIcons.tag, color: cat['color'] as Color),
-              ),
-              title: Text(cat['name'] as String),
-              subtitle: Text('${cat['count']} templates'),
-              trailing: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  IconButton(
-                    icon: const Icon(FontAwesomeIcons.pen),
-                    onPressed: () {},
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : sortedCategories.isEmpty
+              ? Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(FontAwesomeIcons.folderOpen,
+                          size: 48, color: Colors.grey),
+                      const SizedBox(height: 16),
+                      Text('Aucune catégorie',
+                          style: theme.textTheme.bodyLarge),
+                      const SizedBox(height: 8),
+                      Text('Créez des templates pour voir les catégories',
+                          style: theme.textTheme.bodyMedium),
+                    ],
                   ),
-                  IconButton(
-                    icon: const Icon(FontAwesomeIcons.trash, color: Colors.red),
-                    onPressed: () {},
-                  ),
-                ],
-              ),
-            ),
-          );
-        },
-      ),
+                )
+              : ListView.builder(
+                  padding: const EdgeInsets.all(16),
+                  itemCount: sortedCategories.length,
+                  itemBuilder: (context, index) {
+                    final category = sortedCategories[index];
+                    final count = _categoryCounts[category]!;
+                    final color = _getCategoryColor(category);
+                    return Card(
+                      child: ListTile(
+                        leading: CircleAvatar(
+                          backgroundColor: color.withOpacity(0.2),
+                          child: Icon(FontAwesomeIcons.tag, color: color),
+                        ),
+                        title: Text(category),
+                        subtitle:
+                            Text('$count template${count > 1 ? 's' : ''}'),
+                        trailing: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            IconButton(
+                              icon: const Icon(FontAwesomeIcons.pen),
+                              onPressed: () {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                      content: Text(
+                                          'Édition de catégorie à implémenter')),
+                                );
+                              },
+                            ),
+                            IconButton(
+                              icon: const Icon(FontAwesomeIcons.trash,
+                                  color: Colors.red),
+                              onPressed: () {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                      content: Text(
+                                          'Suppression de catégorie à implémenter')),
+                                );
+                              },
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
+                ),
     );
   }
 }


### PR DESCRIPTION
## Summary
Remplacer les catégories hardcodées par un calcul dynamique depuis les templates.

## Changes
- **lib/screens/settings/settings_screen.dart**: 
  - Convert _CategoriesPage to StatefulWidget
  - Load templates via getTemplates()
  - Count templates per category
  - Sort by count descending
  - Show loading/empty states

## Testing
\\\ash
flutter analyze lib/screens/settings/settings_screen.dart
flutter build apk --debug
\\\

## Checklist
- [x] Code compile
- [x] Pas d'erreurs de lint (warnings withOpacity dépréciés)
- [x] Pas de secrets

Closes #12