### PR TITLE
HOTFIX: Fix questions table columns in createTemplate

### DIFF
--- a/lib/powersync/service.dart
+++ b/lib/powersync/service.dart
@@ -561,21 +561,15 @@ class PowerSyncService {
       final questionId = _generateId();
 
       await db.execute('''
-        INSERT INTO questions (id, template_id, type, text, category, "order", required, options, min, max, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO questions (id, template_id, type, text, "order", required, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       ''', [
         questionId,
         id,
         question['type'] as String? ?? 'text',
         question['text'] as String? ?? '',
-        question['category'] as String? ?? category,
         i + 1, // order (1-indexed)
         question['required'] as bool? ?? false ? 1 : 0,
-        question['options'] != null
-            ? (question['options'] as List).join('|')
-            : null,
-        question['min'] as int?,
-        question['max'] as int?,
         now,
         now,
       ]);


### PR DESCRIPTION
## Bug Fix
Fixes SqliteException when creating templates - the INSERT statement was referencing non-existent columns.

## Changes
- Removed category, options, min, max columns from INSERT
- Matches actual SQLite schema: id, template_id, type, text, order, required, created_at, updated_at

## Error Fixed
`
SqliteException(1): table questions has no column named category
`

Closes bug introduced in #24